### PR TITLE
[#21] Improve error messages

### DIFF
--- a/src/Servant/Auth/Hmac/Server.hs
+++ b/src/Servant/Auth/Hmac/Server.hs
@@ -49,8 +49,8 @@ hmacAuthHandler signer sk = mkAuthHandler handler
   where
     handler :: Wai.Request -> Handler ()
     handler req = liftIO (verifySignatureHmac signer sk <$> waiRequestToPayload req) >>= \case
-        True  -> pure ()
-        False -> throwError $ err401 { errBody = "HMAC Auth failed." }
+        Nothing  -> pure ()
+        Just bs -> throwError $ err401 { errBody = bs }
 
 ----------------------------------------------------------------------------
 -- Internals

--- a/src/Servant/Auth/Hmac/Server.hs
+++ b/src/Servant/Auth/Hmac/Server.hs
@@ -49,7 +49,7 @@ hmacAuthHandler signer sk = mkAuthHandler handler
   where
     handler :: Wai.Request -> Handler ()
     handler req = liftIO (verifySignatureHmac signer sk <$> waiRequestToPayload req) >>= \case
-        Nothing  -> pure ()
+        Nothing -> pure ()
         Just bs -> throwError $ err401 { errBody = bs }
 
 ----------------------------------------------------------------------------


### PR DESCRIPTION
Resolves #21 

It seems that `sig == requestSignature signer sk pay` returns `False` in `verifySignatureHmac` function. And that's why it fails.