### PR TITLE
[#29] Add Circle CI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM ubuntu:16.04
+RUN apt-get update && apt-get install wget sudo -y
+RUN wget -qO- https://get.haskellstack.org/ | sh
+RUN stack setup --install-ghc --resolver=lts-12.11
+RUN stack install hlint --resolver=lts-12.11

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,34 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: holmusk/haskell-stack-ci
+    steps:
+      - checkout
+      - restore-cache:
+          key: stack-work-{{ checksum "servant-hmac-auth.cabal" }}
+      - restore-cache:
+          key: stack-global-{{ checksum "stack.yaml" }}
+      - run: stack test --fast
+      - save_cache:
+          key: stack-global-{{ checksum "stack.yaml" }}
+          paths:
+            - "~/.stack"
+      - save_cache:
+          key: stack-work-{{ checksum "servant-hmac-auth.cabal" }}
+          paths:
+            - ".stack-work"
+
+  lint:
+    docker:
+      - image: holmusk/haskell-stack-ci
+    steps:
+      - checkout
+      - run: cd backend && /root/.local/bin/hlint .
+
+workflows:
+  version: 2
+  build_and_test:
+    jobs:
+      - build
+      - lint

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-12.9
+resolver: lts-12.11
 
 ghc-options:
   "$locals": -fhide-source-paths


### PR DESCRIPTION
Resolves #29 

Unfortunately, it doesn't work yet. When I'm calling the following command:

```haskell
docker build .
```

It fails on the last step with the following error message:

```
The command '/bin/sh -c stack install hlint --resolver=lts-12.11' returned a non-zero code: 137
```