### PR TITLE
Add type alias for AuthHandler Wai.Request ()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,5 +8,10 @@ The change log is available [on GitHub][2].
 
 * Initially created.
 
+0.0.1
+=====
+
+* Added type alias `HmacAuthHandler` for `AuthHandler Wai.Request ()`
+
 [1]: https://pvp.haskell.org
 [2]: https://github.com/holmusk/servant-hmac-auth/releases

--- a/servant-hmac-auth.cabal
+++ b/servant-hmac-auth.cabal
@@ -1,6 +1,6 @@
 cabal-version:       2.0
 name:                servant-hmac-auth
-version:             0.0.0
+version:             0.0.1
 description:         Servant authentication with HMAC
 synopsis:            Servant authentication with HMAC
 homepage:            https://github.com/holmusk/servant-hmac-auth

--- a/src/Servant/Auth/Hmac/Server.hs
+++ b/src/Servant/Auth/Hmac/Server.hs
@@ -32,7 +32,8 @@ type HmacAuth = AuthProtect "hmac-auth"
 
 type instance AuthServerData HmacAuth = ()
 
-type HmacAuthContextHandlers = '[AuthHandler Wai.Request ()]
+type HmacAuthResult = AuthHandler Wai.Request ()
+type HmacAuthContextHandlers = '[HmacAuthResult]
 type HmacAuthContext = Context HmacAuthContextHandlers
 
 hmacAuthServerContext
@@ -44,7 +45,7 @@ hmacAuthServerContext signer sk = hmacAuthHandler signer sk :. EmptyContext
 hmacAuthHandler
     :: (SecretKey -> ByteString -> Signature)  -- ^ Signing function
     -> SecretKey  -- ^ Secret key that was used for signing 'Request'
-    -> AuthHandler Wai.Request ()
+    -> HmacAuthResult
 hmacAuthHandler signer sk = mkAuthHandler handler
   where
     handler :: Wai.Request -> Handler ()

--- a/src/Servant/Auth/Hmac/Server.hs
+++ b/src/Servant/Auth/Hmac/Server.hs
@@ -7,6 +7,7 @@ module Servant.Auth.Hmac.Server
        ( HmacAuth
        , HmacAuthContextHandlers
        , HmacAuthContext
+       , HmacAuthHandler
        , hmacAuthServerContext
        , hmacAuthHandler
        ) where
@@ -32,8 +33,8 @@ type HmacAuth = AuthProtect "hmac-auth"
 
 type instance AuthServerData HmacAuth = ()
 
-type HmacAuthResult = AuthHandler Wai.Request ()
-type HmacAuthContextHandlers = '[HmacAuthResult]
+type HmacAuthHandler = AuthHandler Wai.Request ()
+type HmacAuthContextHandlers = '[HmacAuthHandler]
 type HmacAuthContext = Context HmacAuthContextHandlers
 
 hmacAuthServerContext
@@ -45,7 +46,7 @@ hmacAuthServerContext signer sk = hmacAuthHandler signer sk :. EmptyContext
 hmacAuthHandler
     :: (SecretKey -> ByteString -> Signature)  -- ^ Signing function
     -> SecretKey  -- ^ Secret key that was used for signing 'Request'
-    -> HmacAuthResult
+    -> HmacAuthHandler
 hmacAuthHandler signer sk = mkAuthHandler handler
   where
     handler :: Wai.Request -> Handler ()


### PR DESCRIPTION
Hi, I think `HmacAuthResult` is a reasonable name for it. Do you agree? :)
Closes #28 