### PR TITLE
Remove Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-FROM ubuntu:16.04
+FROM ubuntu:20.04
 RUN apt-get update && apt-get install wget sudo -y
 RUN wget -qO- https://get.haskellstack.org/ | sh
-RUN stack setup --install-ghc --resolver=lts-13.2
-RUN stack install hlint --resolver=lts-13.2
+RUN stack setup --install-ghc --resolver=lts-16.31
+RUN stack install hlint --resolver=lts-16.31

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,0 @@
-FROM ubuntu:20.04
-RUN apt-get update && apt-get install wget sudo -y
-RUN wget -qO- https://get.haskellstack.org/ | sh
-RUN stack setup --install-ghc --resolver=lts-16.31
-RUN stack install hlint --resolver=lts-16.31


### PR DESCRIPTION
TBH, I don't know how useful this would be but I've updated the Dockerfile to use newer versions of Ubuntu and GHC.
I tried updating it to use ghc 8.10.7 but installing hlint via stack errors out for some reason.

```
#8 260.1 vector                           > copy/register
#8 260.2 vector                           > Installing library in /root/.stack/snapshots/x86_64-linux-tinfo6/194bc5c2b9551092dea4c34477644af75851e26a8cd787640cd1277bf842229f/8.10.7/lib/x86_64-linux-ghc-8.10.7/vector-0.12.3.1-2QhxFayEJrmJ3PNYTgAmQ3
#8 260.5 vector                           > Registering library for vector-0.12.3.1..
#8 260.6
#8 260.6 --  While building package ghc-lib-parser-ex-8.10.0.23 (scroll up to its section to see the error) using:
#8 260.6       /root/.stack/setup-exe-cache/x86_64-linux-tinfo6/Cabal-simple_mPHDZzAJ_3.2.1.0_ghc-8.10.7 --builddir=.stack-work/dist/x86_64-linux-tinfo6/Cabal-3.2.1.0 build --ghc-options ""
#8 260.6     Process exited with code: ExitFailure 1
------
executor failed running [/bin/sh -c stack install hlint --resolver=lts-18.21]: exit code: 1
```