### PR TITLE
Support `servant-0.19`

### DIFF
--- a/servant-hmac-auth.cabal
+++ b/servant-hmac-auth.cabal
@@ -76,9 +76,9 @@ library
                      , memory >= 0.15 && < 0.17
                      , mtl ^>= 2.2.2
                      , servant ^>= 0.18
-                     , servant-client ^>= 0.18
-                     , servant-client-core ^>= 0.18
-                     , servant-server ^>= 0.18
+                     , servant-client ^>= 0.18 || ^>= 0.19
+                     , servant-client-core ^>= 0.18 || ^>= 0.19
+                     , servant-server ^>= 0.18 || ^>= 0.19
                      , transformers ^>= 0.5
                      , wai ^>= 3.2.2.1
 


### PR DESCRIPTION
Confirmed to build fine when using `allow-newer`