### PR TITLE
Allow base-4.15

### DIFF
--- a/servant-hmac-auth.cabal
+++ b/servant-hmac-auth.cabal
@@ -23,7 +23,7 @@ source-repository head
   location:            https://github.com/holmusk/servant-hmac-auth.git
 
 common common-options
-  build-depends:       base >= 4.11.1.0 && < 4.15
+  build-depends:       base >= 4.11.1.0 && < 4.16
 
   ghc-options:         -Wall
                        -Wincomplete-uni-patterns


### PR DESCRIPTION
This allows servant-hmac-auth to build on GHC 9. I can confirm it builds and passes all of our tests (I haven't ran `servant-hmac-auth` tests).