### PR TITLE
user can now specify signature auth header name

### DIFF
--- a/src/Servant/Auth/Hmac/Client.hs
+++ b/src/Servant/Auth/Hmac/Client.hs
@@ -41,10 +41,9 @@ import Servant.Auth.Hmac.Crypto (
     RequestPayload (..),
     SecretKey,
     Signature (..),
-    keepWhitelistedHeaders,
     requestSignature,
-    signSHA256, 
-    defaultAuthHeaderName
+    signSHA256,
+    defaultAuthHeaderName, keepWhitelistedHeaders'
  )
 
 import qualified Network.HTTP.Client as Client
@@ -129,7 +128,7 @@ servantRequestToPayload authHeaderName url sreq =
         { rpMethod = Client.method req
         , rpContent = "" -- toBsBody $ Client.requestBody req
         , rpHeaders =
-            keepWhitelistedHeaders authHeaderName $
+            keepWhitelistedHeaders' authHeaderName $
                 ("Host", hostAndPort) :
                 ("Accept-Encoding", "gzip") :
                 Client.requestHeaders req
@@ -164,8 +163,9 @@ servantRequestToPayload authHeaderName url sreq =
 
 @
 Authentication: HMAC <signature>
-@
+
 -}
+
 signRequestHmac ::
     -- | Authentication header name
     HeaderName ->

--- a/src/Servant/Auth/Hmac/Client.hs
+++ b/src/Servant/Auth/Hmac/Client.hs
@@ -43,7 +43,8 @@ import Servant.Auth.Hmac.Crypto (
     Signature (..),
     keepWhitelistedHeaders,
     requestSignature,
-    signSHA256,
+    signSHA256, 
+    defaultAuthHeaderName
  )
 
 import qualified Network.HTTP.Client as Client
@@ -76,7 +77,7 @@ defaultHmacSettings sk =
         { hmacSigner = signSHA256
         , hmacSecretKey = sk
         , hmacRequestHook = Nothing
-        , hmacAuthHeaderName = "Authentication"
+        , hmacAuthHeaderName = defaultAuthHeaderName
         }
 
 {- | @newtype@ wrapper over 'ClientM' that signs all outgoing requests

--- a/src/Servant/Auth/Hmac/Crypto.hs
+++ b/src/Servant/Auth/Hmac/Crypto.hs
@@ -14,6 +14,9 @@ module Servant.Auth.Hmac.Crypto (
     verifySignatureHmac,
     whitelistHeaders,
     keepWhitelistedHeaders,
+
+    -- * Internal
+    defaultAuthHeaderName
 ) where
 
 import Crypto.Hash (hash)
@@ -197,6 +200,9 @@ verifySignatureHmac authHeaderName signer sk signedPayload = case unsignedPayloa
 ----------------------------------------------------------------------------
 -- Internals
 ----------------------------------------------------------------------------
+
+defaultAuthHeaderName :: HeaderName
+defaultAuthHeaderName = "Authentication"
 
 isAuthHeader :: HeaderName -> Header -> Bool
 isAuthHeader name = (== name) . fst

--- a/test/Servant/Auth/HmacSpec.hs
+++ b/test/Servant/Auth/HmacSpec.hs
@@ -23,11 +23,10 @@ import Servant.Auth.Hmac (
     HmacAuth,
     SecretKey (SecretKey),
     defaultHmacSettings,
-    hmacAuthServerContext,
     hmacClient,
     runHmacClient,
-    signSHA256, 
-    defaultAuthHeaderName
+    signSHA256,
+    defaultAuthHeaderName, hmacAuthServerContext'
  )
 import Servant.Client (
     BaseUrl (baseUrlPort),
@@ -78,7 +77,7 @@ securedEchoServer :: Server EchoApi
 securedEchoServer = const echoBack
 
 securedEchoApp :: SecretKey -> Application
-securedEchoApp sk = serveWithContext (Proxy @EchoApi) (hmacAuthServerContext defaultAuthHeaderName signSHA256 sk) securedEchoServer
+securedEchoApp sk = serveWithContext (Proxy @EchoApi) (hmacAuthServerContext' defaultAuthHeaderName signSHA256 sk) securedEchoServer
 
 withSecuredEchoApp :: SecretKey -> (Warp.Port -> IO ()) -> IO ()
 withSecuredEchoApp sk = Warp.testWithApplication (pure $ securedEchoApp sk)

--- a/test/Servant/Auth/HmacSpec.hs
+++ b/test/Servant/Auth/HmacSpec.hs
@@ -26,7 +26,8 @@ import Servant.Auth.Hmac (
     hmacAuthServerContext,
     hmacClient,
     runHmacClient,
-    signSHA256,
+    signSHA256, 
+    defaultAuthHeaderName
  )
 import Servant.Client (
     BaseUrl (baseUrlPort),
@@ -77,7 +78,7 @@ securedEchoServer :: Server EchoApi
 securedEchoServer = const echoBack
 
 securedEchoApp :: SecretKey -> Application
-securedEchoApp sk = serveWithContext (Proxy @EchoApi) (hmacAuthServerContext "Authentication" signSHA256 sk) securedEchoServer
+securedEchoApp sk = serveWithContext (Proxy @EchoApi) (hmacAuthServerContext defaultAuthHeaderName signSHA256 sk) securedEchoServer
 
 withSecuredEchoApp :: SecretKey -> (Warp.Port -> IO ()) -> IO ()
 withSecuredEchoApp sk = Warp.testWithApplication (pure $ securedEchoApp sk)

--- a/test/Servant/Auth/HmacSpec.hs
+++ b/test/Servant/Auth/HmacSpec.hs
@@ -77,7 +77,7 @@ securedEchoServer :: Server EchoApi
 securedEchoServer = const echoBack
 
 securedEchoApp :: SecretKey -> Application
-securedEchoApp sk = serveWithContext (Proxy @EchoApi) (hmacAuthServerContext signSHA256 sk) securedEchoServer
+securedEchoApp sk = serveWithContext (Proxy @EchoApi) (hmacAuthServerContext "Authentication" signSHA256 sk) securedEchoServer
 
 withSecuredEchoApp :: SecretKey -> (Warp.Port -> IO ()) -> IO ()
 withSecuredEchoApp sk = Warp.testWithApplication (pure $ securedEchoApp sk)

--- a/test/Servant/Auth/HmacSpec.hs
+++ b/test/Servant/Auth/HmacSpec.hs
@@ -25,8 +25,7 @@ import Servant.Auth.Hmac (
     defaultHmacSettings,
     hmacClient,
     runHmacClient,
-    signSHA256,
-    defaultAuthHeaderName, hmacAuthServerContext'
+    signSHA256, hmacAuthServerContext
  )
 import Servant.Client (
     BaseUrl (baseUrlPort),
@@ -77,7 +76,7 @@ securedEchoServer :: Server EchoApi
 securedEchoServer = const echoBack
 
 securedEchoApp :: SecretKey -> Application
-securedEchoApp sk = serveWithContext (Proxy @EchoApi) (hmacAuthServerContext' defaultAuthHeaderName signSHA256 sk) securedEchoServer
+securedEchoApp sk = serveWithContext (Proxy @EchoApi) (hmacAuthServerContext signSHA256 sk) securedEchoServer
 
 withSecuredEchoApp :: SecretKey -> (Warp.Port -> IO ()) -> IO ()
 withSecuredEchoApp sk = Warp.testWithApplication (pure $ securedEchoApp sk)


### PR DESCRIPTION
Hey! Great library, does everything I need it to...except that the authHeaderName is hardcoded to "Authentication". Some webhooks, such as [Kard's](https://developer.getkard.com/#operation/issuerEarnedRewardWebhook), use `Notify-Signature` or others. So I added the ability to pass an arbitrary header name around. Lemme know if there's anything you'd like done differently :)