### PR TITLE
Increase upper-bounds of bytestring, cryptonite and memory

### DIFF
--- a/servant-hmac-auth.cabal
+++ b/servant-hmac-auth.cabal
@@ -68,13 +68,13 @@ library
 
   build-depends:       base64-bytestring >= 1.0 && <= 2
                      , binary ^>= 0.8
-                     , bytestring ^>= 0.10
+                     , bytestring ^>= 0.10 || ^>= 0.11
                      , case-insensitive ^>= 1.2
                      , containers >= 0.5.7 && < 0.7
-                     , cryptonite >= 0.25 && < 0.30
+                     , cryptonite >= 0.25 && < 0.31
                      , http-types ^>= 0.12
                      , http-client >= 0.6.4 && < 0.8
-                     , memory >= 0.15 && < 0.17
+                     , memory >= 0.15 && < 0.19
                      , mtl ^>= 2.2.2
                      , servant ^>= 0.18 || ^>= 0.19
                      , servant-client ^>= 0.18 || ^>= 0.19


### PR DESCRIPTION
We've been running with `allow-newer: servant-hmac-auth:bytestring, servant-hmac-auth:memory, servant-hmac-auth:cryptonite` for a while now without any problems, so I believe this change is safe.