### PR TITLE
Replace the unmaintained cryptonite with crypton

### DIFF
--- a/servant-hmac-auth.cabal
+++ b/servant-hmac-auth.cabal
@@ -72,7 +72,7 @@ library
                      , bytestring ^>= 0.10 || ^>= 0.11 || ^>= 0.12
                      , case-insensitive ^>= 1.2
                      , containers >= 0.5.7 && < 0.8
-                     , cryptonite >= 0.25 && < 0.31
+                     , crypton >= 0.31 && < 2.0
                      , http-types ^>= 0.12
                      , http-client >= 0.6.4 && < 0.8
                      , memory >= 0.15 && < 0.19

--- a/stack-9.0.2.yaml
+++ b/stack-9.0.2.yaml
@@ -1,1 +1,3 @@
 resolver: lts-19.33
+extra-deps:
+- crypton-1.0.1@sha256:f41316fbc6ad878396e476355e27b70ac35c344d74e3eefafe709e03b192be9e,14527

--- a/stack-9.2.8.yaml
+++ b/stack-9.2.8.yaml
@@ -1,1 +1,3 @@
 resolver: lts-20.26
+extra-deps:
+- crypton-1.0.1@sha256:f41316fbc6ad878396e476355e27b70ac35c344d74e3eefafe709e03b192be9e,14527


### PR DESCRIPTION
This just replaces the deprecated `cryptonite` with the maintained `crypton` package. The latter is a fork and is a drop-in replacement.